### PR TITLE
Add .ers script and update usage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.ps1]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# ─────────── EOL normalization ───────────
+*               text=auto
+
+# Force LF for code, including executable Rust scripts…
+*.rs            text eol=lf
+*.ers           text eol=lf
+*.sh            text eol=lf
+*.toml          text eol=lf
+*.md            text eol=lf
+
+# …but allow CRLF on Windows for PowerShell
+*.ps1           text eol=crlf
+
+# Binary files
+*.png           binary
+*.jpg           binary
+*.exe           binary
+*.dll           binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Rust build artifacts
+/target/
+*.rs.bk
+Cargo.lock
+
+# OS cruft
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# IDE / editor
+.vscode/
+.idea/
+
+# Swap / temp
+*~
+*.swp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,24 @@
-What:
-  * This repo is for building rust scripts.
-Why:
-  * The reason this repo exists is to create cross-platform non-PowerShell, non-python, and non-bash scripts.
+# Development Resources
+
+This repository is for building cross-platform Rust scripts. All scripts run with `rust-script` instead of Cargo.
+
+## Script format
+
+Every Rust script should:
+
+1. Use the `.ers` extension.
+2. Start with the shebang:
+
+   ```rust
+   #!/usr/bin/env rust-script
+   ```
+
+Mark new scripts executable so they can run directly on Unix-like systems:
+
+```bash
+chmod +x my_script.ers
+git add my_script.ers
+git update-index --chmod=+x my_script.ers
+```
+
+The repo already includes files like `.gitattributes` and `.gitignore` for cross-platform behavior.

--- a/README.md
+++ b/README.md
@@ -1,144 +1,39 @@
 # make-rust-script-do-stuff
 
-What:
-  * This repo is for building rust scripts.
+This repository hosts cross-platform scripts written in Rust and executed with [`rust-script`](https://rust-script.org/).
 
-Why:
-  * The reason this repo exists is to create cross-platform non-PowerShell, non-python, and non-bash scripts.
+## Running scripts
 
-## Running Rust Scripts
-
-Rust scripts can be executed with [`rust-script`](https://rust-script.org/). Install it once using Cargo:
+Install `rust-script` using Cargo:
 
 ```sh
 cargo install rust-script
 ```
 
-After installation you can run a script on **any platform** with:
+Run any script by pointing `rust-script` at it:
 
 ```sh
-rust-script your_script.rs
+rust-script your_script.ers
 ```
 
-On Unix systems you may embed a shebang line so scripts run directly:
+### Shebang and extension
+
+Start each script with a shebang so it can run directly on Unix-like systems:
 
 ```rust
 #!/usr/bin/env rust-script
 ```
 
-On Windows you can associate the `.ers` extension with `rust-script` so scripts run just like any other executable. Run once:
+Name scripts with the `.ers` extension and mark them executable. On Windows, run once:
 
 ```powershell
 rust-script --install-file-association
 ```
 
-Renaming `your_script.rs` to `your_script.ers` then lets you double-click it.
-
-For maximum portability, keep the shebang line and use the `.ers` extension.
-After associating the extension or marking the file executable, you can run the
-script directly:
+Afterwards you can execute the script just like any other file:
 
 ```bash
 ./your_script.ers
 ```
 
-## Cross-platform Repository Setup
-
-Below are recommended settings so your shebang'ed Rust scripts work everywhere.
-
-### 1. `.gitattributes`
-
-```gitattributes
-# ─────────── EOL normalization ───────────
-*               text=auto
-
-# Force LF for code, including executable Rust scripts…
-*.rs            text eol=lf
-*.ers           text eol=lf
-*.sh            text eol=lf
-*.toml          text eol=lf
-*.md            text eol=lf
-
-# …but allow CRLF on Windows for PowerShell
-*.ps1           text eol=crlf
-
-# Binary files
-*.png           binary
-*.jpg           binary
-*.exe           binary
-*.dll           binary
-```
-
-> • Treat your renamed `.ers` files just like `.rs` so they always check out with LF.
-> • `text=auto` covers Markdown, TOML, JSON, etc., but you can explicitly list `.sh`, `.toml`, or `.md` for extra certainty.
-
-### 2. `.gitignore`
-
-```gitignore
-# Rust build artifacts
-/target/
-*.rs.bk
-Cargo.lock
-
-# OS cruft
-.DS_Store
-Thumbs.db
-desktop.ini
-
-# IDE / editor
-.vscode/
-.idea/
-
-# Swap / temp
-*~
-*.swp
-```
-
-### 3. (Optional) `.editorconfig`
-
-```editorconfig
-root = true
-
-[*]
-charset = utf-8
-indent_style = space
-indent_size = 4
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-[*.ps1]
-end_of_line = crlf
-```
-
-### 4. Mark your scripts executable
-
-On Unix-like shells, once you’ve added your new script:
-
-```bash
-chmod +x my_script.rs    # or .ers
-git add my_script.rs
-git update-index --chmod=+x my_script.rs
-git commit -m "Make my_script.rs executable"
-```
-
-Git will now track the "+x" bit so anyone cloning on Linux/macOS can just run:
-
-```bash
-./my_script.rs
-```
-
-and on Windows they can double-click `my_script.ers` (after running `rust-script --install-file-association` once).
-
-### 5. Embed the shebang in every script
-
-At the very top of each script file:
-
-````rust
-#!/usr/bin/env rust-script
-//! ```cargo
-//! [dependencies]
-//! …
-//! ```
-````
-
+Development resources live in [AGENTS.md](AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -5,3 +5,140 @@ What:
 
 Why:
   * The reason this repo exists is to create cross-platform non-PowerShell, non-python, and non-bash scripts.
+
+## Running Rust Scripts
+
+Rust scripts can be executed with [`rust-script`](https://rust-script.org/). Install it once using Cargo:
+
+```sh
+cargo install rust-script
+```
+
+After installation you can run a script on **any platform** with:
+
+```sh
+rust-script your_script.rs
+```
+
+On Unix systems you may embed a shebang line so scripts run directly:
+
+```rust
+#!/usr/bin/env rust-script
+```
+
+On Windows you can associate the `.ers` extension with `rust-script` so scripts run just like any other executable. Run once:
+
+```powershell
+rust-script --install-file-association
+```
+
+Renaming `your_script.rs` to `your_script.ers` then lets you double-click it.
+
+For maximum portability, keep the shebang line and use the `.ers` extension.
+After associating the extension or marking the file executable, you can run the
+script directly:
+
+```bash
+./your_script.ers
+```
+
+## Cross-platform Repository Setup
+
+Below are recommended settings so your shebang'ed Rust scripts work everywhere.
+
+### 1. `.gitattributes`
+
+```gitattributes
+# ─────────── EOL normalization ───────────
+*               text=auto
+
+# Force LF for code, including executable Rust scripts…
+*.rs            text eol=lf
+*.ers           text eol=lf
+*.sh            text eol=lf
+*.toml          text eol=lf
+*.md            text eol=lf
+
+# …but allow CRLF on Windows for PowerShell
+*.ps1           text eol=crlf
+
+# Binary files
+*.png           binary
+*.jpg           binary
+*.exe           binary
+*.dll           binary
+```
+
+> • Treat your renamed `.ers` files just like `.rs` so they always check out with LF.
+> • `text=auto` covers Markdown, TOML, JSON, etc., but you can explicitly list `.sh`, `.toml`, or `.md` for extra certainty.
+
+### 2. `.gitignore`
+
+```gitignore
+# Rust build artifacts
+/target/
+*.rs.bk
+Cargo.lock
+
+# OS cruft
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# IDE / editor
+.vscode/
+.idea/
+
+# Swap / temp
+*~
+*.swp
+```
+
+### 3. (Optional) `.editorconfig`
+
+```editorconfig
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.ps1]
+end_of_line = crlf
+```
+
+### 4. Mark your scripts executable
+
+On Unix-like shells, once you’ve added your new script:
+
+```bash
+chmod +x my_script.rs    # or .ers
+git add my_script.rs
+git update-index --chmod=+x my_script.rs
+git commit -m "Make my_script.rs executable"
+```
+
+Git will now track the "+x" bit so anyone cloning on Linux/macOS can just run:
+
+```bash
+./my_script.rs
+```
+
+and on Windows they can double-click `my_script.ers` (after running `rust-script --install-file-association` once).
+
+### 5. Embed the shebang in every script
+
+At the very top of each script file:
+
+````rust
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [dependencies]
+//! …
+//! ```
+````
+

--- a/gci.ers
+++ b/gci.ers
@@ -1,0 +1,116 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [dependencies]
+//! clap = { version = "4", features = ["derive"] }
+//! serde = { version = "1", features = ["derive"] }
+//! serde_json = "1"
+//! walkdir = "2"
+//! globset = "0.4"
+//! ```
+
+
+/**
+Usage:
+    rust-script gci.ers [--path <PATH>] [--depth <DEPTH>] [--filter <PATTERN>] [--hidden]
+
+After associating the `.ers` extension on Windows or marking the file executable
+on Unix, you can run it directly:
+
+    ./gci.ers [options]
+
+Options:
+    --path      Directory to search. Defaults to current directory.
+    --depth     Maximum recursion depth. Defaults to unlimited.
+    --filter    Glob pattern filter applied to file names.
+    --hidden    Include hidden files and folders.
+*/
+
+use clap::Parser;
+use serde::Serialize;
+use std::path::{PathBuf};
+use walkdir::{WalkDir, DirEntry};
+use globset::{Glob, GlobSet};
+
+#[derive(Parser, Debug)]
+#[command(version, about = "List files in a directory as JSON")] 
+struct Args {
+    /// Directory to search
+    #[arg(long, default_value = ".")]
+    path: PathBuf,
+
+    /// Maximum recursion depth (unlimited by default)
+    #[arg(long, default_value_t = usize::MAX)]
+    depth: usize,
+
+    /// Glob pattern filter
+    #[arg(long)]
+    filter: Option<String>,
+
+    /// Include hidden files and directories
+    #[arg(long)]
+    hidden: bool,
+}
+
+#[derive(Serialize)]
+struct Entry {
+    path: String,
+    is_dir: bool,
+}
+
+fn build_glob(pattern: &Option<String>) -> Option<GlobSet> {
+    pattern.as_ref().map(|pat| {
+        let glob = Glob::new(pat).expect("invalid glob pattern");
+        let mut builder = globset::GlobSetBuilder::new();
+        builder.add(glob);
+        builder.build().expect("failed to build glob")
+    })
+}
+
+#[cfg(unix)]
+fn is_hidden(entry: &DirEntry) -> bool {
+    entry.file_name().to_str().map_or(false, |s| s.starts_with('.'))
+}
+
+#[cfg(windows)]
+fn is_hidden(entry: &DirEntry) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    if let Ok(md) = entry.metadata() {
+        if md.file_attributes() & 0x2 != 0 {
+            return true;
+        }
+    }
+    entry.file_name().to_str().map_or(false, |s| s.starts_with('.'))
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let glob = build_glob(&args.filter);
+    let mut items = Vec::new();
+
+    for entry in WalkDir::new(&args.path).max_depth(args.depth) {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(err) => {
+                eprintln!("{}", err);
+                continue;
+            }
+        };
+        if !args.hidden && is_hidden(&entry) {
+            continue;
+        }
+        if let Some(ref set) = glob {
+            if !set.is_match(entry.file_name()) {
+                continue;
+            }
+        }
+        items.push(Entry {
+            path: entry.path().display().to_string(),
+            is_dir: entry.file_type().is_dir(),
+        });
+    }
+
+    let json = serde_json::to_string_pretty(&items)?;
+    println!("{}", json);
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- rename `gci.rs` to `gci.ers`
- document running scripts with `.ers` extension for best cross-platform support
- refine `.gitattributes` and `.gitignore` patterns

## Testing
- `rust-script gci.ers --depth 1 --filter '*.rs' > /tmp/out.json`
- `rust-script gci.ers --depth 1 --filter '*.md' > /tmp/md.json`


------
https://chatgpt.com/codex/tasks/task_e_68526e99a86883249689b9110e452542