### PR TITLE
Update docs for .ers scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,24 @@
-What:
-  * This repo is for building rust scripts.
-Why:
-  * The reason this repo exists is to create cross-platform non-PowerShell, non-python, and non-bash scripts.
+# Development Resources
+
+This repository is for building cross-platform Rust scripts. All scripts run with `rust-script` instead of Cargo.
+
+## Script format
+
+Every Rust script should:
+
+1. Use the `.ers` extension.
+2. Start with the shebang:
+
+   ```rust
+   #!/usr/bin/env rust-script
+   ```
+
+Mark new scripts executable so they can run directly on Unix-like systems:
+
+```bash
+chmod +x my_script.ers
+git add my_script.ers
+git update-index --chmod=+x my_script.ers
+```
+
+The repo already includes files like `.gitattributes` and `.gitignore` for cross-platform behavior.

--- a/README.md
+++ b/README.md
@@ -1,144 +1,39 @@
 # make-rust-script-do-stuff
 
-What:
-  * This repo is for building rust scripts.
+This repository hosts cross-platform scripts written in Rust and executed with [`rust-script`](https://rust-script.org/).
 
-Why:
-  * The reason this repo exists is to create cross-platform non-PowerShell, non-python, and non-bash scripts.
+## Running scripts
 
-## Running Rust Scripts
-
-Rust scripts can be executed with [`rust-script`](https://rust-script.org/). Install it once using Cargo:
+Install `rust-script` using Cargo:
 
 ```sh
 cargo install rust-script
 ```
 
-After installation you can run a script on **any platform** with:
+Run any script by pointing `rust-script` at it:
 
 ```sh
-rust-script your_script.rs
+rust-script your_script.ers
 ```
 
-On Unix systems you may embed a shebang line so scripts run directly:
+### Shebang and extension
+
+Start each script with a shebang so it can run directly on Unix-like systems:
 
 ```rust
 #!/usr/bin/env rust-script
 ```
 
-On Windows you can associate the `.ers` extension with `rust-script` so scripts run just like any other executable. Run once:
+Name scripts with the `.ers` extension and mark them executable. On Windows, run once:
 
 ```powershell
 rust-script --install-file-association
 ```
 
-Renaming `your_script.rs` to `your_script.ers` then lets you double-click it.
-
-For maximum portability, keep the shebang line and use the `.ers` extension.
-After associating the extension or marking the file executable, you can run the
-script directly:
+Afterwards you can execute the script just like any other file:
 
 ```bash
 ./your_script.ers
 ```
 
-## Cross-platform Repository Setup
-
-Below are recommended settings so your shebang'ed Rust scripts work everywhere.
-
-### 1. `.gitattributes`
-
-```gitattributes
-# ─────────── EOL normalization ───────────
-*               text=auto
-
-# Force LF for code, including executable Rust scripts…
-*.rs            text eol=lf
-*.ers           text eol=lf
-*.sh            text eol=lf
-*.toml          text eol=lf
-*.md            text eol=lf
-
-# …but allow CRLF on Windows for PowerShell
-*.ps1           text eol=crlf
-
-# Binary files
-*.png           binary
-*.jpg           binary
-*.exe           binary
-*.dll           binary
-```
-
-> • Treat your renamed `.ers` files just like `.rs` so they always check out with LF.
-> • `text=auto` covers Markdown, TOML, JSON, etc., but you can explicitly list `.sh`, `.toml`, or `.md` for extra certainty.
-
-### 2. `.gitignore`
-
-```gitignore
-# Rust build artifacts
-/target/
-*.rs.bk
-Cargo.lock
-
-# OS cruft
-.DS_Store
-Thumbs.db
-desktop.ini
-
-# IDE / editor
-.vscode/
-.idea/
-
-# Swap / temp
-*~
-*.swp
-```
-
-### 3. (Optional) `.editorconfig`
-
-```editorconfig
-root = true
-
-[*]
-charset = utf-8
-indent_style = space
-indent_size = 4
-end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-[*.ps1]
-end_of_line = crlf
-```
-
-### 4. Mark your scripts executable
-
-On Unix-like shells, once you’ve added your new script:
-
-```bash
-chmod +x my_script.rs    # or .ers
-git add my_script.rs
-git update-index --chmod=+x my_script.rs
-git commit -m "Make my_script.rs executable"
-```
-
-Git will now track the "+x" bit so anyone cloning on Linux/macOS can just run:
-
-```bash
-./my_script.rs
-```
-
-and on Windows they can double-click `my_script.ers` (after running `rust-script --install-file-association` once).
-
-### 5. Embed the shebang in every script
-
-At the very top of each script file:
-
-````rust
-#!/usr/bin/env rust-script
-//! ```cargo
-//! [dependencies]
-//! …
-//! ```
-````
-
+Development resources live in [AGENTS.md](AGENTS.md).


### PR DESCRIPTION
## Summary
- simplify AGENTS instructions about using `.ers` files
- trim README to reference AGENTS only for development resources

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685278c319688324bb2b2b2522498c93