### PR TITLE
Document Jira scopes for boarder.ers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,15 @@ To obtain the initial authorization code, print the consent URL:
 
 Open the URL, authorize the app and pass the resulting code via
 `--auth-code` when starting the server.
+
+The app requires a Jira OAuth token with the following scopes:
+
+```
+offline_access
+read:jira-user
+manage:jira-configuration
+manage:jira-project
+manage:jira-webhook
+write:jira-work
+read:jira-work
+```


### PR DESCRIPTION
## Summary
- clarify the OAuth scopes required by `boarder.ers`

## Testing
- `rust-script boarder.ers --help | head` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_685b701a872c832492b463c977b50ea1