### PR TITLE
Fix async lock usage and add runtime guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,13 @@ text:
 
 For more involved changes, run the script with typical options to verify its
 behaviour.
+
+### Runtime tips
+
+Async scripts should avoid common pitfalls that lead to deadlocks or needless
+blocking:
+
+* Never hold a `Mutex` or `RwLock` guard across an `.await`. Clone or copy the
+  data you need first, then release the lock before calling async functions.
+* Use the async versions of file and network APIs whenever possible.
+* Be mindful of spawned tasks and clean them up when your program exits.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Afterwards you can execute the script just like any other file:
 
 Development resources live in [AGENTS.md](AGENTS.md).
 
+## Avoiding common async pitfalls
+
+When writing or modifying these scripts keep a few runtime considerations in mind:
+
+* Do not hold locks (e.g. `RwLock` guards) across `.await` points. Clone the
+  needed data first, release the lock and then perform async work.
+* Prefer async file and network APIs from `tokio`/`reqwest` to avoid blocking the
+  executor.
+* If you spawn background tasks ensure they are awaited or detached properly so
+  the program can shut down cleanly.
+
+
 ## boarder.ers
 
 `boarder.ers` implements a tiny service that refreshes Atlassian Jira OAuth

--- a/boarder.ers
+++ b/boarder.ers
@@ -120,31 +120,40 @@ async fn request_new_tokens(cfg: &Config, grant: Grant) -> anyhow::Result<TokenR
 }
 
 async fn renew_tokens(state: &Arc<RwLock<AppState>>, auth_code_once: &mut Option<String>) {
-    let mut st = state.write().await;
-    let refresh_opt = if let Some(tok) = st.token.as_ref() {
-        Some(tok.refresh_token.clone())
-    } else {
-        load_refresh_token(&st.store).await
+    // clone data without holding the lock across .await
+    let (cfg, token_opt, store) = {
+        let st = state.read().await;
+        (st.cfg.clone(), st.token.clone(), st.store.clone())
     };
+
+    let refresh_opt = if let Some(tok) = token_opt {
+        Some(tok.refresh_token)
+    } else {
+        load_refresh_token(&store).await
+    };
+
     let grant = if let Some(ref_token) = refresh_opt {
         Grant::Refresh(ref_token)
     } else if let Some(code) = auth_code_once.take() {
         Grant::AuthCode(code)
     } else {
         eprintln!("First run needs --auth-code. Open this URL to obtain it:\n{}",
-                  auth_url(&st.cfg));
+                  auth_url(&cfg));
         return;
     };
 
-    match request_new_tokens(&st.cfg, grant).await {
+    match request_new_tokens(&cfg, grant).await {
         Ok(resp) => {
             let expires_at = Utc::now() + ChronoDuration::seconds(resp.expires_in);
+            if let Err(e) = save_refresh_token(&store, &resp.refresh_token).await {
+                eprintln!("Failed to save refresh token: {e}");
+            }
+            let mut st = state.write().await;
             st.token = Some(TokenInfo {
                 access_token: resp.access_token.clone(),
                 refresh_token: resp.refresh_token.clone(),
                 expires_at,
             });
-            let _ = save_refresh_token(&st.store, &resp.refresh_token).await;
             eprintln!("Token renewed, expires at {}", expires_at);
         }
         Err(e) => {


### PR DESCRIPTION
## Summary
- document how to avoid common async pitfalls
- mention runtime tips in AGENTS.md
- avoid holding write lock across `.await` in `boarder.ers`

## Testing
- `rust-script boarder.ers --help`
- `rust-script gci.ers --help`
- `rust-script irm.ers --help`
- `rust-script subnet_ping_seeker.ers --help`
- `rust-script whisper_transcribe.ers --help`


------
https://chatgpt.com/codex/tasks/task_e_6861163ab2c083249d378101816f79b5