### PR TITLE
Add ready-drafts command

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,12 @@ read:jira-work
 ## gh_pr_hydra.ers
 
 `gh_pr_hydra.ers` offers several GitHub pull request utilities. You can merge PRs
-by author, query mergeability and detect conflicting file changes.
+by author, query mergeability, detect conflicting file changes and mark draft PRs
+ready for review.
 
 ```bash
 ./gh_pr_hydra.ers merge-serial --author <username>
+./gh_pr_hydra.ers ready-drafts --author <username>
 ```
 
 ## ipmi_scan.ers

--- a/gh_pr_hydra.ers
+++ b/gh_pr_hydra.ers
@@ -47,6 +47,13 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         what_if: bool,
     },
+    /// Mark draft PRs by author as ready for review
+    ReadyDrafts {
+        #[arg(long)]
+        author: String,
+        #[arg(long, default_value_t = false)]
+        what_if: bool,
+    },
 }
 
 fn run_command(cmd: &mut Command) -> Result<String, Box<dyn Error>> {
@@ -143,6 +150,8 @@ struct PrItem {
     title: String,
     #[serde(rename = "headRefName")]
     head_ref_name: Option<String>,
+    #[serde(rename = "isDraft")]
+    is_draft: Option<bool>,
     mergeable: Option<String>,
     files: Option<Vec<FileItem>>, // for view
 }
@@ -246,6 +255,33 @@ fn merge_conflicts(author: &str) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+fn ready_drafts(author: &str, what_if: bool) -> Result<(), Box<dyn Error>> {
+    println!("[Ready Drafts] Converting {author}'s draft PRs to ready for review...");
+    let mut cmd = Command::new("gh");
+    cmd.args(["pr", "list", "--author", author, "--state", "open", "--json", "number,title,isDraft"]);
+    let out = run_command(&mut cmd)?;
+    let prs: Vec<PrItem> = serde_json::from_str(&out)?;
+    let drafts: Vec<_> = prs.into_iter().filter(|p| p.is_draft.unwrap_or(false)).collect();
+    if drafts.is_empty() {
+        println!("No draft PRs found for {author}.");
+        return Ok(());
+    }
+    for pr in drafts {
+        println!("Draft PR #{}: '{}'", pr.number, pr.title);
+        if what_if {
+            println!("  Would mark ready for review");
+        } else {
+            let mut rc = Command::new("gh");
+            rc.args(["pr", "ready", &pr.number.to_string()]);
+            match rc.status() {
+                Ok(st) if st.success() => println!("  \u{2713} Marked ready"),
+                _ => eprintln!("  \u{2717} Failed to mark ready"),
+            }
+        }
+    }
+    Ok(())
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
     match cli.command {
@@ -256,6 +292,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             let repo = get_repo()?;
             remove_branch_safe(&branch, &repo, what_if)?;
         }
+        Commands::ReadyDrafts { author, what_if } => ready_drafts(&author, what_if)?,
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- extend `gh_pr_hydra.ers` with a `ready-drafts` command to mark draft PRs as ready for review
- document the new capability in the README

## Testing
- `rust-script gh_pr_hydra.ers --help`

------
https://chatgpt.com/codex/tasks/task_e_68612ec8bbc8832487421b5c73afa0d5