### PR TITLE
Fix GH CLI URL encoding

### DIFF
--- a/gh_pr_hydra.ers
+++ b/gh_pr_hydra.ers
@@ -4,6 +4,7 @@
 //! clap = { version = "4", features = ["derive"] }
 //! serde = { version = "1", features = ["derive"] }
 //! serde_json = "1"
+//! urlencoding = "2"
 //! ```
 
 use clap::{Parser, Subcommand};
@@ -11,6 +12,7 @@ use serde::Deserialize;
 use std::process::Command;
 use std::error::Error;
 use std::io::{self, Write};
+use urlencoding::encode;
 
 #[derive(Parser)]
 #[command(author, version, about = "GitHub PR Hydra Toolkit (rust-script edition)")]
@@ -120,7 +122,8 @@ fn test_branch_deletion_safety(branch: &str, repo: &str) -> Result<bool, Box<dyn
         return Ok(false);
     }
     let mut cmd = Command::new("gh");
-    cmd.args(["api", &format!("repos/{}/branches/{}", repo, branch)]);
+    let b = encode(branch);
+    cmd.args(["api", &format!("repos/{}/branches/{}", repo, b)]);
     let out = run_command(&mut cmd)?;
     let info: BranchInfo = serde_json::from_str(&out)?;
     if info.protected {
@@ -144,7 +147,8 @@ fn remove_branch_safe(branch: &str, repo: &str, what_if: bool) -> Result<(), Box
         return Ok(());
     }
     let mut cmd = Command::new("gh");
-    cmd.args(["api", "-X", "DELETE", &format!("repos/{}/git/refs/heads/{}", repo, branch)]);
+    let b = encode(branch);
+    cmd.args(["api", "-X", "DELETE", &format!("repos/{}/git/refs/heads/{}", repo, b)]);
     match cmd.status() {
         Ok(st) if st.success() => println!("\u{2713} Deleted remote branch '{}'", branch),
         _ => eprintln!("\u{2717} Failed to delete '{}'", branch),
@@ -207,7 +211,8 @@ fn merge_serial(author: &str, delete_branch: bool, what_if: bool) -> Result<(), 
             println!("\u{2713} PR #{pr_number} merged.");
             if delete_branch {
                 let mut check = Command::new("gh");
-                check.args(["api", &format!("repos/{}/branches/{}", repo, branch), "-q", ".name"]);
+                let b = encode(&branch);
+                check.args(["api", &format!("repos/{}/branches/{}", repo, b), "-q", ".name"]);
                 let branch_exists = check.output()?.status.success();
                 if branch_exists {
                     println!("\u{2022} Remote branch '{}' still exists; performing safety checks…", branch);

--- a/irm.ers
+++ b/irm.ers
@@ -25,6 +25,7 @@
 use clap::{ArgAction, Parser, ValueEnum};
 use reqwest::blocking::{Client, ClientBuilder, Response};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, USER_AGENT};
+use reqwest::Url;
 use serde_json::Value;
 use std::error::Error;
 use std::fs;
@@ -147,6 +148,8 @@ fn build_headers(pairs: &[(String, String)], ct: &Option<String>, token: &Option
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
+    let url = Url::parse(&args.url)
+        .map_err(|e| format!("Invalid URL '{}': {e}", args.url))?;
 
     // Build reqwest client
     let client: Client = ClientBuilder::new()
@@ -156,7 +159,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build()?;
 
     // Assemble request
-    let mut req = client.request(to_reqwest_method(args.method), &args.url);
+    let mut req = client.request(to_reqwest_method(args.method), url);
 
     // Headers
     req = req.headers(build_headers(&args.headers, &args.content_type, &args.token)?);


### PR DESCRIPTION
## Summary
- add urlencoding crate to gh_pr_hydra.ers
- percent encode branch names when building gh api paths
- validate URL input in irm.ers

## Testing
- `rust-script gh_pr_hydra.ers --help`
- `./irm.ers --help`


------
https://chatgpt.com/codex/tasks/task_e_686204a65c548324bb276a79ea2461fd