### PR TITLE
Fix gh_pr_hydra clean-merged pruning

### DIFF
--- a/gh_pr_hydra.ers
+++ b/gh_pr_hydra.ers
@@ -173,6 +173,12 @@ fn clean_merged_branches(repo: &str, what_if: bool) -> Result<(), Box<dyn Error>
     for branch in list_branches(repo)? {
         remove_branch_safe(&branch, repo, what_if)?;
     }
+    // Prune local references to the branches we just deleted so a second run
+    // isn't required to clean them up.
+    let status = Command::new("git").args(["fetch", "--prune"]).status();
+    if status.map(|s| !s.success()).unwrap_or(true) {
+        eprintln!("Warning: final 'git fetch --prune' failed");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- clean-merged now performs a second `git fetch --prune` after deleting remote
  branches so local references are removed immediately

## Testing
- `rust-script gh_pr_hydra.ers --help`

------
https://chatgpt.com/codex/tasks/task_e_68620c6bda0c8324a5365f18b4f653ac