### PR TITLE
Cleanup merged branches by checking PR state

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Get-ChildItem -Directory -Depth 0 | ForEach-Object -Process {
 
 * The branch is not the default branch.
 * The branch is not marked as protected on GitHub.
-* Its latest commit is an ancestor of the default branch, ensuring it was fully
-  merged.
+* Its latest commit is an ancestor of the default branch, or the branch has a
+  merged pull request, ensuring it was fully merged.
 
 
 ## ipmi_scan.ers

--- a/gh_pr_hydra.ers
+++ b/gh_pr_hydra.ers
@@ -87,6 +87,30 @@ struct Commit {
     sha: String,
 }
 
+#[derive(Deserialize)]
+struct PrCheck {
+    number: u64,
+}
+
+fn branch_has_merged_pr(repo: &str, branch: &str) -> Result<bool, Box<dyn Error>> {
+    let mut cmd = Command::new("gh");
+    cmd.args([
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "merged",
+        "--head",
+        branch,
+        "--json",
+        "number",
+    ]);
+    let out = run_command(&mut cmd)?;
+    let prs: Vec<PrCheck> = serde_json::from_str(&out)?;
+    Ok(!prs.is_empty())
+}
+
 fn get_repo() -> Result<String, Box<dyn Error>> {
     let mut cmd = Command::new("gh");
     cmd.args(["repo", "view", "--json", "nameWithOwner"]);
@@ -129,6 +153,9 @@ fn test_branch_deletion_safety(branch: &str, repo: &str) -> Result<bool, Box<dyn
     if info.protected {
         eprintln!("\u{2022} '{}' is protected; skipping.", branch);
         return Ok(false);
+    }
+    if branch_has_merged_pr(repo, branch)? {
+        return Ok(true);
     }
     let mut mb = Command::new("git");
     mb.args(["merge-base", "--is-ancestor", &info.commit.sha, &format!("origin/{}", default)]);


### PR DESCRIPTION
## Summary
- adjust README to note merged PR detection
- allow `gh_pr_hydra.ers` to delete branches that have merged PRs even if commit ancestry diverged

## Testing
- `rust-script gh_pr_hydra.ers --help`

------
https://chatgpt.com/codex/tasks/task_e_686272a76678832498c28619ced52fac