### PR TITLE
Fix gh_pr_hydra merge-conflicts parsing

### DIFF
--- a/gh_pr_hydra.ers
+++ b/gh_pr_hydra.ers
@@ -357,7 +357,7 @@ mod internal {
         for pr in &prs {
             println!("Fetching files for PR #{}", pr.number);
             let mut cmd = Command::new("gh");
-            cmd.args(["pr", "view", &pr.number.to_string(), "--json", "files"]);
+            cmd.args(["pr", "view", &pr.number.to_string(), "--json", "number,title,files"]);
             let out = run(&mut cmd)?;
             if !out.status.success() {
                 bail!("`gh pr view` failed: {}", String::from_utf8_lossy(&out.stderr));


### PR DESCRIPTION
## Summary
- include number and title fields when viewing PR files

## Testing
- `rust-script gh_pr_hydra.ers --help`

------
https://chatgpt.com/codex/tasks/task_e_6864dfdee75883249b6c64621affa828