### PR TITLE
Apply lint hygiene steps

### DIFF
--- a/gh_pr_hydra.ers
+++ b/gh_pr_hydra.ers
@@ -37,7 +37,6 @@ use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 use serde::Deserialize;
 use std::process::{Command, Output};
-use std::io::{self, Write};
 use urlencoding::encode;
 
 #[derive(Parser)]
@@ -92,8 +91,10 @@ enum Commands {
     },
 }
 
+#[allow(clippy::redundant_pub_crate, clippy::uninlined_format_args)]
 mod internal {
-    use super::*;
+    use super::{bail, encode, Command, Context, Deserialize, Output, Result};
+    use std::io::{self, Write};
 
     pub(crate) fn run(cmd: &mut Command) -> Result<Output> {
         cmd.output()
@@ -110,11 +111,12 @@ mod internal {
             }
             bail!("`gh repo view` failed: {}", String::from_utf8_lossy(&output.stderr));
         }
+        #[allow(clippy::items_after_statements)]
         #[derive(Deserialize)]
         struct Perm { #[serde(rename = "viewerPermission")] viewer_permission: Option<String> }
         let perm: Perm = serde_json::from_slice(&output.stdout)?;
         match perm.viewer_permission.as_deref() {
-            Some("ADMIN") | Some("MAINTAIN") | Some("WRITE") => Ok(()),
+            Some("ADMIN" | "MAINTAIN" | "WRITE") => Ok(()),
             _ => bail!("Current GitHub account lacks push permission to this repository. Ensure you're logged into the correct account."),
         }
     }
@@ -160,6 +162,7 @@ mod internal {
         if !out.status.success() {
             bail!("`gh repo view` failed: {}", String::from_utf8_lossy(&out.stderr));
         }
+        #[allow(clippy::items_after_statements)]
         #[derive(Deserialize)]
         struct Repo {
             #[serde(rename = "nameWithOwner")]
@@ -176,11 +179,13 @@ mod internal {
         if !out.status.success() {
             bail!("`gh repo view` failed: {}", String::from_utf8_lossy(&out.stderr));
         }
+        #[allow(clippy::items_after_statements)]
         #[derive(Deserialize)]
         struct Ref {
             #[serde(rename = "defaultBranchRef")]
             default_branch_ref: DefaultRef,
         }
+        #[allow(clippy::items_after_statements)]
         #[derive(Deserialize)]
         struct DefaultRef { name: String }
         let r: Ref = serde_json::from_slice(&out.stdout)?;
@@ -190,7 +195,7 @@ mod internal {
     pub(crate) fn test_branch_deletion_safety(branch: &str, repo: &str) -> Result<bool> {
         let default = get_default_branch()?;
         if branch == default {
-            eprintln!("\u{2022} '{}' is the default branch; skipping.", branch);
+            eprintln!("\u{2022} {branch} is the default branch; skipping.");
             return Ok(false);
         }
         let mut cmd = Command::new("gh");
@@ -202,17 +207,17 @@ mod internal {
         }
         let info: BranchInfo = serde_json::from_slice(&out.stdout)?;
         if info.protected {
-            eprintln!("\u{2022} '{}' is protected; skipping.", branch);
+            eprintln!("\u{2022} {branch} is protected; skipping.");
             return Ok(false);
         }
         if branch_has_merged_pr(repo, branch)? {
             return Ok(true);
         }
         let mut mb = Command::new("git");
-        mb.args(["merge-base", "--is-ancestor", &info.commit.sha, &format!("origin/{}", default)]);
+        mb.args(["merge-base", "--is-ancestor", &info.commit.sha, &format!("origin/{default}")]);
         let out = run(&mut mb)?;
         if !out.status.success() {
-            eprintln!("\u{2022} '{}' is not fully merged into '{}'; skipping.", branch, default);
+            eprintln!("\u{2022} {branch} is not fully merged into {default}; skipping.");
             return Ok(false);
         }
         Ok(true)
@@ -221,18 +226,18 @@ mod internal {
     pub(crate) fn remove_branch_safe(branch: &str, repo: &str, what_if: bool) -> Result<()> {
         if !test_branch_deletion_safety(branch, repo)? { return Ok(()); }
         if what_if {
-            println!("Would delete remote branch '{}'", branch);
+            println!("Would delete remote branch {branch}");
             return Ok(());
         }
         let mut cmd = Command::new("gh");
-        let path = format!("heads/{}", branch);
+        let path = format!("heads/{branch}");
         let r = encode(&path);
-        cmd.args(["api", "-X", "DELETE", &format!("repos/{}/git/refs/{}", repo, r)]);
+        cmd.args(["api", "-X", "DELETE", &format!("repos/{repo}/git/refs/{r}")]);
         let out = run(&mut cmd)?;
         if out.status.success() {
-            println!("\u{2713} Deleted remote branch '{}'", branch);
+            println!("\u{2713} Deleted remote branch {branch}");
         } else {
-            eprintln!("\u{2717} Failed to delete '{}'", branch);
+            eprintln!("\u{2717} Failed to delete {branch}");
         }
         Ok(())
     }
@@ -244,7 +249,7 @@ mod internal {
         if !out.status.success() {
             bail!("`gh api` failed: {}", String::from_utf8_lossy(&out.stderr));
         }
-        Ok(String::from_utf8_lossy(&out.stdout).lines().map(|s| s.to_string()).collect())
+        Ok(String::from_utf8_lossy(&out.stdout).lines().map(str::to_string).collect())
     }
 
     pub(crate) fn clean_merged_branches(repo: &str, what_if: bool) -> Result<()> {
@@ -307,13 +312,13 @@ mod internal {
                 if delete_branch {
                     let mut check = Command::new("gh");
                     let b = encode(&branch);
-                    check.args(["api", &format!("repos/{}/branches/{}", repo, b), "-q", ".name"]);
+                    check.args(["api", &format!("repos/{repo}/branches/{b}"), "-q", ".name"]);
                     let branch_exists = run(&mut check)?.status.success();
                     if branch_exists {
-                        println!("\u{2022} Remote branch '{}' still exists; performing safety checks…", branch);
+                        println!("\u{2022} Remote branch {branch} still exists; performing safety checks…");
                         remove_branch_safe(&branch, &repo, what_if)?;
                     } else {
-                        println!("\u{2022} Remote branch '{}' confirmed deleted.", branch);
+                        println!("\u{2022} Remote branch {branch} confirmed deleted.");
                     }
                 }
             } else {
@@ -340,11 +345,11 @@ mod internal {
         let conflicted: Vec<_> = prs.iter().filter(|p| p.mergeable.as_deref() == Some("CONFLICTING")).collect();
         let unknown: Vec<_> = prs.iter().filter(|p| p.mergeable.is_none() || p.mergeable.as_deref() == Some("UNKNOWN")).collect();
         println!("\nMergeable PRs:");
-        if mergeable.is_empty() { println!("  (none)"); } else { for p in mergeable { println!("  \u{2713} PR #{}: '{}'", p.number, p.title); } }
+        if mergeable.is_empty() { println!("  (none)"); } else { for p in mergeable { println!("  \u{2713} PR #{number}: {title}", number=p.number, title=p.title); } }
         println!("\nPRs with merge conflicts:");
-        if conflicted.is_empty() { println!("  (none)"); } else { for p in conflicted { println!("  \u{2717} PR #{}: '{}'", p.number, p.title); } }
+        if conflicted.is_empty() { println!("  (none)"); } else { for p in conflicted { println!("  \u{2717} PR #{number}: {title}", number=p.number, title=p.title); } }
         println!("\nPRs with unknown mergeability (prophecy unclear):");
-        if unknown.is_empty() { println!("  (none)"); } else { for p in unknown { println!("  ? PR #{}: '{}'", p.number, p.title); } }
+        if unknown.is_empty() { println!("  (none)"); } else { for p in unknown { println!("  ? PR #{number}: {title}", number=p.number, title=p.title); } }
         Ok(())
     }
 
@@ -360,7 +365,7 @@ mod internal {
         println!("Found {} open PR(s).", prs.len());
         let mut files_map = std::collections::HashMap::new();
         for pr in &prs {
-            println!("Fetching files for PR #{}", pr.number);
+            println!("Fetching files for PR #{pr_number}", pr_number = pr.number);
             let mut cmd = Command::new("gh");
             cmd.args(["pr", "view", &pr.number.to_string(), "--json", "number,title,files"]);
             let out = run(&mut cmd)?;
@@ -379,7 +384,7 @@ mod internal {
                     let overlap: Vec<&String> = files_a.iter().filter(|f| files_b.contains(*f)).collect();
                     if !overlap.is_empty() {
                         let list = overlap.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", ");
-                        eprintln!("PR #{} and PR #{} both modify: {}", a, b, list);
+                        eprintln!("PR #{a} and PR #{b} both modify: {list}");
                         conflict_found = true;
                     }
                 }
@@ -407,7 +412,7 @@ mod internal {
             return Ok(());
         }
         for pr in drafts {
-            println!("Draft PR #{}: '{}'", pr.number, pr.title);
+            println!("Draft PR #{number}: {title}", number = pr.number, title = pr.title);
             if what_if {
                 println!("  Would mark ready for review");
             } else {
@@ -430,12 +435,12 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     if let Some(path) = cli.repo_path.as_deref() {
         std::env::set_current_dir(path)
-            .with_context(|| format!("Failed to change directory to '{}'", path))?;
+            .with_context(|| format!("Failed to change directory to '{path}'"))?;
         let mut check = Command::new("git");
         check.args(["rev-parse", "--is-inside-work-tree"]);
         let out = internal::run(&mut check)?;
         if !out.status.success() {
-            bail!("'{}' is not a git repository", path);
+            bail!("'{path}' is not a git repository");
         }
     }
     internal::ensure_gh_ready()?;
@@ -458,7 +463,7 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::internal::*;
+    use super::internal::run;
     use std::process::Command;
     #[test]
     fn run_reports_missing_binary() {


### PR DESCRIPTION
## Summary
- follow the lint fix workflow from AGENTS.md for `gh_pr_hydra.ers`
- keep helpers `pub(crate)` but use explicit imports
- inline format arguments and add Clippy allowances
- silence `items_after_statements` warnings for embedded structs

## Testing
- `./gh_pr_hydra.ers --help`
- `cargo clippy --manifest-path "$pkg/Cargo.toml" --all-targets --all-features -- -D warnings -D clippy::all -D clippy::pedantic -D clippy::nursery`

------
https://chatgpt.com/codex/tasks/task_e_686636d4da7c83249b7ef31c288ce12b