### PR TITLE
Clarify redirect URI for boarder

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ To obtain the initial authorization code, print the consent URL:
 Open the URL, authorize the app and pass the resulting code via
 `--auth-code` when starting the server.
 
+The Atlassian OAuth configuration typically allows only
+`http://localhost:8080` as the redirect URI. The script defaults to that
+port for both the redirect URI and the token service. Use
+`--redirect-port` if your app permits a different redirect URI and
+`--port` to change the listening port for API calls.
+
 The app requires a Jira OAuth token with the following scopes:
 
 ```

--- a/boarder.ers
+++ b/boarder.ers
@@ -32,6 +32,12 @@ struct Args {
     /// Print the URL to obtain the initial authorization code and exit
     #[arg(long)]
     print_auth_url: bool,
+    /// Port for the local OAuth redirect URI. Atlassian usually expects
+    /// `http://localhost:8080`, so change this only if your OAuth app
+    /// accepts a different port.
+    #[arg(long, default_value_t = 8080)]
+    redirect_port: u16,
+    /// Port the token service listens on. Use this in API calls.
     #[arg(long, default_value_t = 8080)]
     port: u16,
 }
@@ -194,7 +200,7 @@ async fn main() -> anyhow::Result<()> {
     let cfg = Config {
         client_id: args.client_id,
         client_secret: args.client_secret,
-        redirect_uri: format!("http://localhost:{}", args.port),
+        redirect_uri: format!("http://localhost:{}", args.redirect_port),
     };
 
     if args.print_auth_url {


### PR DESCRIPTION
## Summary
- clarify the Atlassian redirect port expectation
- note the same caveat in the README
- allow different listener vs OAuth ports

## Testing
- `./boarder.ers --help`


------
https://chatgpt.com/codex/tasks/task_e_6877199404fc8324ae6778b155c6620c