### PR TITLE
Handle missing auth for boarder

### DIFF
--- a/boarder.ers
+++ b/boarder.ers
@@ -216,6 +216,10 @@ async fn main() -> anyhow::Result<()> {
         renew_tokens(&state, &mut ac).await;
     }
 
+    if state.read().await.token.is_none() {
+        return Ok(());
+    }
+
     let st_clone = state.clone();
     let ac_clone = auth_code_once.clone();
     tokio::spawn(async move {


### PR DESCRIPTION
## Summary
- exit from `boarder.ers` if no refresh token nor auth code is available

## Testing
- `./boarder.ers --help`
- `./boarder.ers --client-id foo --client-secret bar`

------
https://chatgpt.com/codex/tasks/task_e_6877792a6268832493a8dae13b3dcdf3